### PR TITLE
expose explicit unicast_target_ip attribute for greater config flexibility

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default['heartbeat']['config']['authkeys'] = nil
 default['heartbeat']['config']['active_key'] = nil
 default['heartbeat']['config']['mode'] = nil
 default['heartbeat']['config']['interface'] = nil
+default['heartbeat']['config']['unicast_target_ip'] = nil
 default['heartbeat']['config']['mcast_group'] = nil
 default['heartbeat']['config']['mcast_ttl'] = nil
 default['heartbeat']['config']['resource_ip'] = nil

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -35,6 +35,7 @@ heartbeat "heartbeat" do
   active_key node['heartbeat']['config']['active_key']
   mode node['heartbeat']['config']['mode']
   interface node['heartbeat']['config']['interface']
+  unicast_target_ip node['heartbeat']['config']['unicast_target_ip']
   mcast_group node['heartbeat']['config']['mcast_group']
   mcast_ttl node['heartbeat']['config']['mcast_ttl']
   resources node['heartbeat']['config']['resource_ip']

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -43,6 +43,7 @@ attribute :authkeys, :kind_of => [Array, String], :required => true
 attribute :active_key, :kind_of => Integer
 attribute :mode, :equal_to => [:bcast, 'bcast', :mcast, 'mcast', :ucast, 'ucast'], :default => :ucast
 attribute :interface, :kind_of => [String, Array], :default => node['network']['default_interface']
+attribute :unicast_target_ip, :kind_of => String, :default => node['network']['interfaces'][node['network']['default_interface']]['addresses'].select { |address, data| data['family'] == 'inet' }.keys[0]
 attribute :mcast_group, :kind_of => String
 attribute :mcast_ttl, :kind_of => Integer, :default => 1
 attribute :resource_groups, :default => []

--- a/templates/default/ha.cf.erb
+++ b/templates/default/ha.cf.erb
@@ -13,7 +13,7 @@ warntime <%= @heartbeat.warntime %>
 <% case @heartbeat.mode.to_sym -%>
 <% when :ucast -%>
 <% @nodes.select{|n| n['macaddress'] != node['macaddress']}.each do |n| -%>
-ucast <%=@interface.first %> <%= n['ipaddress'] %>
+ucast <%=@interface.first %> <%= n['heartbeat']['config']['unicast_target_ip'] %>
 <% end -%>
 <% when :bcast -%>
 bcast <%= @interface.join(' ') %>


### PR DESCRIPTION
this seems a little more flexible than making any assumptions based on interface
