### PR TITLE
Stop using deprecated chef::Mixin:recipeDefinitionDSLCore

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -21,7 +21,7 @@ class Chef
   class Resource
     class HeartbeatResourceGroup
       include Chef::Mixin::ParamsValidate
-      include Chef::Mixin::RecipeDefinitionDSLCore
+      include Chef::DSL::Recipe
 
       attr_reader :run_context, :cookbook_name, :recipe_name, :sub_resources
 


### PR DESCRIPTION
Resolves a Foodcritic rule before we ship it.